### PR TITLE
Feature/cors

### DIFF
--- a/apps/backend/.env-template
+++ b/apps/backend/.env-template
@@ -9,3 +9,11 @@ KEYSTORE_PASSWORD="<keystore-password>"
 # optional
 # default: "production"
 KTOR_ENV=development
+
+# The origins that are allowed to make requests to the API backend.
+# For production environments this variable is required to be set.
+# For development environments this variable will be set to: "https://localhost.admin.craftsmans-ledger.net:7100,https://localhost.www.craftsmans-ledger.net:7000,https://admin-dev.craftsmans-ledger.nl.eu.org,https://www-dev.craftsmans-ledger.nl.eu.org"
+# type:     A comma seperated string
+# optional
+# default:
+#CORS_ALLOWED_ORIGINS=

--- a/apps/backend/build.gradle.kts
+++ b/apps/backend/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cors)
     implementation(libs.ktor.server.host.common)
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.status.pages)

--- a/apps/backend/src/main/kotlin/org/eu/nl/craftsmansledger/core/AppRoutes.kt
+++ b/apps/backend/src/main/kotlin/org/eu/nl/craftsmansledger/core/AppRoutes.kt
@@ -1,13 +1,12 @@
 package org.eu.nl.craftsmansledger.core
 
 import io.ktor.http.*
-import io.ktor.serialization.JsonConvertException
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.http.content.*
 import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.plugins.statuspages.*
-import io.ktor.server.request.receive
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.json.Json
@@ -15,12 +14,24 @@ import org.eu.nl.craftsmansledger.items.itemRoutes
 import org.eu.nl.craftsmansledger.technologyTrees.technologyTreeRoutes
 
 fun Application.appRoutes() {
+    val allowedDevOrigins = "https://localhost.admin.craftsmans-ledger.net:7100,https://localhost.www.craftsmans-ledger.net:7000,https://admin-dev.craftsmans-ledger.nl.eu.org,https://www-dev.craftsmans-ledger.nl.eu.org"
+
+    val ktorEnv = System.getenv("KTOR_ENV")
+    val allowedOrigins = System.getenv("CORS_ALLOWED_ORIGINS") ?: if (ktorEnv == "production") "" else allowedDevOrigins
+
     install(ContentNegotiation) {
         json(Json {
             isLenient = false
             prettyPrint = true
             allowStructuredMapKeys = false
         })
+    }
+    install(CORS) {
+        allowMethod(HttpMethod.Get)
+        allowMethod(HttpMethod.Post)
+        allowMethod(HttpMethod.Put)
+        allowMethod(HttpMethod.Delete)
+        allowOrigins { it -> if (allowedOrigins == "*") true else allowedOrigins.split(",").contains(it)  }
     }
 
     routing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ ktor-network-tls-certicates = { module = "io.ktor:ktor-network-tls-certificates"
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor-version" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor-version" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor-version" }
+ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor-version" }
 ktor-server-host-common = { module = "io.ktor:ktor-server-host-common", version.ref = "ktor-version" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor-version" }
 ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor-version" }


### PR DESCRIPTION
* Configure CORS for the API backend.

By default, when the app runs in production, the `CORS_ALLOWED_ORIGINS` environment variable needs to be set, otherwise no origins are allowed to make requests to the API backend. In an development environment the following origins are allowed to make requests to the API backend (but this can obviously be overwritten by setting the environment variable:

- https://admin-dev.craftsmans-ledger.nl.eu.org
- https://dev.craftsmans-ledger.nl.eu.org
- https://localhost.admin.craftsmans-ledger.net:7100
- https://localhost.www.craftsmans-ledger.net:7000