### PR TITLE
Feature/cml 12 cache get all resources

### DIFF
--- a/apps/admin-portal/src/app/core/config/app.config.ts
+++ b/apps/admin-portal/src/app/core/config/app.config.ts
@@ -1,7 +1,12 @@
 import { provideHttpClient } from '@angular/common/http';
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideBrowserStorage, provideClientConfig, provideErrorHandler } from '@craftsmans-ledger/shared-ui';
+import {
+    initializeResourceServices,
+    provideBrowserStorage,
+    provideClientConfig,
+    provideErrorHandler,
+} from '@craftsmans-ledger/shared-ui';
 import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
@@ -10,6 +15,7 @@ export const appConfig: ApplicationConfig = {
         provideZonelessChangeDetection(),
         provideRouter(appRoutes),
         provideHttpClient(),
+        initializeResourceServices(),
         provideClientConfig(),
         provideBrowserStorage(),
         provideErrorHandler(),

--- a/apps/admin-portal/src/app/core/root/root.component.ts
+++ b/apps/admin-portal/src/app/core/root/root.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { NotificationsContainerComponent } from '@craftsmans-ledger/shared-ui';
+import { NotificationsContainerComponent, WebSocketService } from '@craftsmans-ledger/shared-ui';
 import { HeaderComponent } from '../header';
 
 @Component({
@@ -10,4 +10,14 @@ import { HeaderComponent } from '../header';
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [RouterOutlet, HeaderComponent, NotificationsContainerComponent],
 })
-export class RootComponent {}
+export class RootComponent implements OnInit, OnDestroy {
+    private readonly webSocketService = inject(WebSocketService);
+
+    public ngOnInit() {
+        this.webSocketService.connect();
+    }
+
+    public ngOnDestroy() {
+        this.webSocketService.closeConnection();
+    }
+}

--- a/apps/web-app/src/app/core/root/root.component.ts
+++ b/apps/web-app/src/app/core/root/root.component.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { WebSocketService } from '@craftsmans-ledger/shared-ui';
 import { HeaderComponent } from '../header';
 
 @Component({
@@ -9,4 +10,14 @@ import { HeaderComponent } from '../header';
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [RouterModule, HeaderComponent],
 })
-export class RootComponent {}
+export class RootComponent implements OnInit, OnDestroy {
+    private readonly webSocketService = inject(WebSocketService);
+
+    public ngOnInit() {
+        this.webSocketService.connect();
+    }
+
+    public ngOnDestroy() {
+        this.webSocketService.closeConnection();
+    }
+}

--- a/libs/shared-ui/src/lib/browser-storage/browser-storage.service.ts
+++ b/libs/shared-ui/src/lib/browser-storage/browser-storage.service.ts
@@ -1,12 +1,19 @@
 import { inject, Injectable } from '@angular/core';
+import { tryCatch } from '../utils';
 import { BROWSER_STORAGE } from './providers';
 
 @Injectable({ providedIn: 'root' })
 export class BrowserStorageService {
     private readonly storage = inject(BROWSER_STORAGE);
 
-    public getItem(key: string) {
-        return JSON.parse(this.storage.getItem(key));
+    public async getItem(key: string) {
+        const { data, error } = await tryCatch(() => JSON.parse(this.storage.getItem(key)));
+
+        if (error) {
+            this.removeItem(key);
+            return null;
+        }
+        return data;
     }
 
     public setItem<T>(key: string, value: T) {

--- a/libs/shared-ui/src/lib/browser-storage/models.ts
+++ b/libs/shared-ui/src/lib/browser-storage/models.ts
@@ -1,0 +1,7 @@
+export const StorageKeys = {
+    CACHE_ITEMS: 'items',
+    CACHE_TECHNOLOGY_TREES: 'technology-trees',
+    CACHE_RECIPES: 'recipes',
+} as const;
+
+export type StorageKey = (typeof StorageKeys)[keyof typeof StorageKeys];

--- a/libs/shared-ui/src/lib/cache/cache.service.ts
+++ b/libs/shared-ui/src/lib/cache/cache.service.ts
@@ -1,0 +1,43 @@
+import { inject, Type } from '@angular/core';
+import { BrowserStorageService, Resource, serializeAll } from '@craftsmans-ledger/shared-ui';
+import { StorageKey } from '../browser-storage/models';
+
+export class CacheService<T extends Resource> {
+    private readonly browserStorageService = inject(BrowserStorageService);
+
+    private _cache: T[] = [];
+
+    private readonly resourceType: Type<T>;
+
+    private readonly storageKey: StorageKey;
+
+    constructor(storageKey: StorageKey, resourceType: Type<T>) {
+        this.storageKey = storageKey;
+        this.resourceType = resourceType;
+    }
+
+    public async loadCacheFromStorage() {
+        const cache = serializeAll(this.resourceType, await this.browserStorageService.getItem(this.storageKey));
+
+        if (!cache) return;
+        this.cache = cache;
+    }
+
+    public get cache() {
+        return this._cache;
+    }
+
+    public set cache(resources: T[]) {
+        this._cache = [...resources].sort((curr, next) => curr.label().localeCompare(next.label()));
+        this.browserStorageService.setItem(this.storageKey, this._cache);
+    }
+
+    public get hasCache() {
+        return this._cache.length !== 0;
+    }
+
+    public clear() {
+        this._cache = [];
+        this.browserStorageService.removeItem(this.storageKey);
+    }
+}

--- a/libs/shared-ui/src/lib/cache/index.ts
+++ b/libs/shared-ui/src/lib/cache/index.ts
@@ -1,0 +1,1 @@
+export * from './cache.service';

--- a/libs/shared-ui/src/lib/http/api.service.ts
+++ b/libs/shared-ui/src/lib/http/api.service.ts
@@ -8,24 +8,26 @@ export class ApiService {
     private readonly requestService = inject(RequestService);
     private readonly configService = inject(ConfigService);
 
-    public baseApiUrl = this.configService.config.baseApiUrl;
-
     public get<Response, QueryParamName extends string = string>(
         endPoint: string,
         queryParams?: QueryParams<QueryParamName>
     ) {
-        return this.requestService.get<Response>(`${this.baseApiUrl}${endPoint}`, queryParams);
+        const baseApiUrl = this.configService.config.baseApiUrl;
+        return this.requestService.get<Response>(`${baseApiUrl}${endPoint}`, queryParams);
     }
 
     public post<RequestBody, Response>(endpoint: string, body: RequestBody) {
-        return this.requestService.post<RequestBody, Response>(`${this.baseApiUrl}${endpoint}`, body);
+        const baseApiUrl = this.configService.config.baseApiUrl;
+        return this.requestService.post<RequestBody, Response>(`${baseApiUrl}${endpoint}`, body);
     }
 
     public put<RequestBody, Response = RequestBody>(endpoint: string, body: RequestBody) {
-        return this.requestService.put<RequestBody, Response>(`${this.baseApiUrl}${endpoint}`, body);
+        const baseApiUrl = this.configService.config.baseApiUrl;
+        return this.requestService.put<RequestBody, Response>(`${baseApiUrl}${endpoint}`, body);
     }
 
     public delete(endPoint: string) {
-        return this.requestService.delete(`${this.baseApiUrl}${endPoint}`);
+        const baseApiUrl = this.configService.config.baseApiUrl;
+        return this.requestService.delete(`${baseApiUrl}${endPoint}`);
     }
 }

--- a/libs/shared-ui/src/lib/index.ts
+++ b/libs/shared-ui/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './browser-storage';
+export * from './cache';
 export * from './config';
 export * from './crypto';
 export * from './error-handling';

--- a/libs/shared-ui/src/lib/resources/index.ts
+++ b/libs/shared-ui/src/lib/resources/index.ts
@@ -1,4 +1,5 @@
 export * from './items';
 export * from './models';
+export * from './providers';
 export * from './recipes';
 export * from './technology-trees';

--- a/libs/shared-ui/src/lib/resources/providers.ts
+++ b/libs/shared-ui/src/lib/resources/providers.ts
@@ -1,0 +1,15 @@
+import { inject, provideAppInitializer } from '@angular/core';
+import { forkJoin } from 'rxjs';
+import { ItemsService } from './items';
+import { RecipesService } from './recipes';
+import { TechnologyTreesService } from './technology-trees';
+
+export function initializeResourceServices() {
+    return provideAppInitializer(() => {
+        const itemsService = inject(ItemsService);
+        const technologyTreesService = inject(TechnologyTreesService);
+        const recipesService = inject(RecipesService);
+
+        return forkJoin([technologyTreesService.initialize(), itemsService.initialize(), recipesService.initialize()]);
+    });
+}

--- a/libs/shared-ui/src/lib/web-socket/models.ts
+++ b/libs/shared-ui/src/lib/web-socket/models.ts
@@ -2,12 +2,25 @@ export const WebSocketMessageTypes = {
     INVALIDATE_CACHE: 'invalidate-cache',
 } as const;
 
-export type WebSocketMessageType = (typeof WebSocketMessageTypes)[keyof typeof WebSocketMessageTypes];
+type WebSocketMessageType = (typeof WebSocketMessageTypes)[keyof typeof WebSocketMessageTypes];
 
 export interface WebSocketMessage {
     type: WebSocketMessageType;
 }
 
+export const ResourceTypes = {
+    TECHNOLOGY_TREES: 'TechnologyTrees',
+    RECIPES: 'Recipes',
+    ITEMS: 'Items',
+} as const;
+
+export type ResourceType = (typeof ResourceTypes)[keyof typeof ResourceTypes];
+
+export interface InvalidateCacheData {
+    resourceType: ResourceType;
+}
+
 export class InvalidateCacheMessage implements WebSocketMessage {
     public type = WebSocketMessageTypes.INVALIDATE_CACHE;
+    public data: InvalidateCacheData;
 }


### PR DESCRIPTION
* Use BrowserStorageService and new CacheService to cache resources in the SessionStorage.
* Receive resources from the cache first before fetching data from the API backend.
* Implement client-side caching for `getAll` end-points for all resources.

Implements another step for #38 