### PR TITLE
Add shared TypeScript config package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ A personal companion tool for Medieval Dynasty: track unlocked recipes, find ven
 
 Early development: repository scaffolding in progress.
 
+## Project Structure
+
+- `apps/` — deployable applications (currently empty; created lazily once the first app lands)
+- `libs/` — shared *application* code consumed at runtime by `apps/*` (currently empty)
+- `packages/` — shared *build/tooling* config, consumed by name (e.g. `@craftsmans-ledger/tsconfig`), not by relative path
+
+See [ADR-0003](docs/adr/0003-libs-vs-packages-split.md) for the full runtime/build-time rationale.
+
+Currently populated packages:
+
+- [`@craftsmans-ledger/tsconfig`](packages/tsconfig) — shared, environment-agnostic TypeScript compiler options; see [ADR-0011](docs/adr/0011-per-framework-typescript-catalogs.md) for why framework-specific overlays aren't included yet.
+
 ## Getting Started
 
 This project uses [mise](https://mise.jdx.dev/) to manage the Node.js and pnpm versions, reading them directly from `package.json` instead of a separate `mise.toml`. See [ADR-0001](docs/adr/0001-moonrepo-mise-pnpm-for-monorepo-tooling.md) and [ADR-0002](docs/adr/0002-mise-as-sole-toolchain-version-authority.md) for the rationale.

--- a/docs/adr/0011-per-framework-typescript-catalogs.md
+++ b/docs/adr/0011-per-framework-typescript-catalogs.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+---
+
+# Per-framework pnpm catalogs for TypeScript, not a shared tooling pin
+
+Angular and NestJS — the frameworks this monorepo is built around ([ADR-0001](./0001-moonrepo-mise-pnpm-for-monorepo-tooling.md)) — currently support different maximum TypeScript versions: Angular supports TypeScript 6, NestJS doesn't yet. Rather than adding `typescript` to the existing `catalog:tooling` pnpm catalog, which would force every consumer onto one pinned version, each framework gets its own named pnpm catalog (e.g. `catalog:angular`, `catalog:nest`) so its app can pin the TypeScript version that framework actually supports. `packages/tsconfig/base.json` stays limited to environment-agnostic `compilerOptions` (the `strict` family, `esModuleInterop`, `skipLibCheck`, etc.) with no `target`/`module`/`moduleResolution`/`lib`, so the same base can be extended by a future `angular.json` and `nest.json` overlay regardless of which TypeScript version each ends up pinning.
+
+## Considered Options
+
+- **A single shared `typescript` entry in `catalog:tooling`** — rejected, since it would force one version across frameworks with different support ceilings.
+
+## Consequences
+
+- Framework-specific overlays (`angular.json`, `nest.json`) stay deferred until each app actually exists, same as [ADR-0004](./0004-husky-lint-staged-for-git-hooks.md)'s precedent.
+- `base.json` alone is intentionally incomplete — it won't compile anything until an overlay supplies `target`/`module`/`moduleResolution`/`lib`.

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,0 +1,15 @@
+# @craftsmans-ledger/tsconfig
+
+Shared, environment-agnostic TypeScript compiler options for Craftsman's Ledger apps.
+
+## Usage
+
+Extend `base.json` from an app's own `tsconfig.json`:
+
+```json
+{
+  "extends": "@craftsmans-ledger/tsconfig/base.json"
+}
+```
+
+`base.json` deliberately excludes `target`, `module`, `moduleResolution`, and `lib` — those are environment-specific and belong to a framework overlay (e.g. `angular.json`, `nest.json`), which doesn't exist yet since no app has landed. See [ADR-0011](../../docs/adr/0011-per-framework-typescript-catalogs.md) for the rationale.

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "compilerOptions": {
+        "allowUnreachableCode": false,
+        "allowUnusedLabels": false,
+        "esModuleInterop": true,
+        "exactOptionalPropertyTypes": true,
+        "forceConsistentCasingInFileNames": true,
+        "newLine": "lf",
+        "noErrorTruncation": true,
+        "noImplicitOverride": true,
+        "noImplicitReturns": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "strict": true
+    }
+}

--- a/packages/tsconfig/moon.yml
+++ b/packages/tsconfig/moon.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../.moon/cache/schemas/project.json
+
+layer: "configuration"
+stack: "unknown"
+
+project:
+    title: "TypeScript Config"
+    description: "Shared, environment-agnostic TypeScript compiler options consumed by name from other packages/apps."

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@craftsmans-ledger/tsconfig",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared, environment-agnostic TypeScript compiler options for Craftsman's Ledger apps.",
+  "author": "NoNamer777",
+  "license": "MIT",
+  "homepage": "https://github.com/nonamer777/craftsmans-ledger/tree/main/packages/tsconfig#readme",
+  "bugs": {
+    "url": "https://github.com/nonamer777/craftsmans-ledger/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nonamer777/craftsmans-ledger.git",
+    "directory": "packages/tsconfig"
+  },
+  "files": [
+    "base.json",
+    "README.md"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,8 @@ importers:
         specifier: catalog:tooling
         version: 4.3.0(prettier@3.9.4)(typescript@6.0.3)
 
+  packages/tsconfig: {}
+
 packages:
 
   '@babel/code-frame@7.29.7':


### PR DESCRIPTION
## What

Adds `packages/tsconfig`, a new shared workspace package with an environment-agnostic `base.json` (the `strict` family, `esModuleInterop`, unused-code checks, etc.), its `package.json`, `moon.yml`, and README. Also adds `docs/adr/0011-per-framework-typescript-catalogs.md` and a new "Project Structure" section in the root README.

## Why

Angular and NestJS, the two frameworks this monorepo is built around, currently support different maximum TypeScript versions, so pinning `typescript` into the existing shared `catalog:tooling` pnpm catalog would force both onto one version. ADR-0011 records using a separate named pnpm catalog per framework instead, and keeping `base.json` limited to environment-agnostic options (no `target`/`module`/`moduleResolution`/`lib`) so it can be extended by framework-specific overlays once Angular and NestJS apps actually exist. `packages/tsconfig` also needed to land before `packages/eslint-config`, since TypeScript-aware ESLint rules depend on a tsconfig shape already being in place.

## How to Review

Start with `packages/tsconfig/base.json` to see the actual compiler options chosen, then `docs/adr/0011-per-framework-typescript-catalogs.md` for the reasoning behind deferring framework-specific overlays. The `README.md` changes and package `README.md` are documentation-only and safe to skim.

## Testing

- [x] `pnpm moon ci` passes locally
- [x] Manually verified: `pnpm prettier --check` passes on all new/changed files

## Deployment Notes

None.