### PR TITLE
Add Tailwind v4 styling and move Angular workspace to repo root

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
         "moon": {
             "command": "pnpm",
             "args": ["moon", "mcp"]
+        },
+        "angular-cli": {
+            "command": "pnpm",
+            "args": ["ng", "mcp"]
         }
     }
 }

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -4,6 +4,7 @@
 
 plugins:
     - prettier-plugin-organize-imports
+    - prettier-plugin-tailwindcss
 
 singleQuote: true
 quoteProps: 'consistent'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,7 @@
 ## Pull requests
 
 This repo uses GitHub for pull requests. For configuration, see [docs/agents/pull-requests.md](docs/agents/pull-requests.md).
+
+## MCP servers
+
+This repo registers MCP servers for AI coding assistants in `.mcp.json`. For what's registered and known issues, see [docs/agents/mcp-servers.md](docs/agents/mcp-servers.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [ADR-0003](docs/adr/0003-libs-vs-packages-split.md) for the full runtime/bui
 
 Currently populated apps:
 
-- [`web`](apps/web): the main Angular web client; a self-contained Angular CLI workspace with zoneless change detection and Vitest as its test runner, see [ADR-0012](docs/adr/0012-self-contained-angular-workspace-per-app.md) and [ADR-0013](docs/adr/0013-zoneless-vitest-testing-stack.md). Currently a shell only: no domain routes/components yet.
+- [`web`](apps/web): the main Angular web client; a project in the shared root `angular.json` workspace ([ADR-0020](docs/adr/0020-root-level-angular-workspace.md)) with zoneless change detection and Vitest as its test runner, see [ADR-0013](docs/adr/0013-zoneless-vitest-testing-stack.md). Currently a shell only: no domain routes/components yet.
 
 Currently populated packages:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project uses [mise](https://mise.jdx.dev/) to manage the Node.js and pnpm v
 2. `mise install`: installs the pinned Node.js and pnpm versions
 3. `pnpm install`: installs workspace dependencies
 
-Task orchestration is handled by [moon](https://moonrepo.dev/) (`pnpm moon <command>`); see [ADR-0001](docs/adr/0001-moonrepo-mise-pnpm-for-monorepo-tooling.md) for why. Its `.mcp.json` also registers a moon MCP server for Claude Code, letting the assistant query the project/task graph directly (`get_project`, `get_tasks`, `get_changed_files`, etc.) without extra setup.
+Task orchestration is handled by [moon](https://moonrepo.dev/) (`pnpm moon <command>`); see [ADR-0001](docs/adr/0001-moonrepo-mise-pnpm-for-monorepo-tooling.md) for why. See [docs/agents/mcp-servers.md](docs/agents/mcp-servers.md) for the MCP servers `.mcp.json` registers for AI coding assistants.
 
 ### Formatting
 

--- a/angular.json
+++ b/angular.json
@@ -2,8 +2,10 @@
     "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
     "version": 1,
     "cli": {
-        "packageManager": "pnpm"
+        "packageManager": "pnpm",
+        "analytics": false
     },
+    "newProjectRoot": "libs",
     "schematics": {
         "@schematics/angular:component": {
             "changeDetection": "OnPush",
@@ -13,24 +15,27 @@
     "projects": {
         "web": {
             "projectType": "application",
-            "root": "",
-            "sourceRoot": "src",
-            "prefix": "app",
+            "root": "apps/web",
+            "sourceRoot": "apps/web/src",
+            "prefix": "web",
             "architect": {
                 "build": {
                     "builder": "@angular/build:application",
                     "options": {
                         "assets": [
                             {
-                                "glob": "**/*",
-                                "input": "public"
+                                "input": "apps/web/public",
+                                "glob": "**/*"
                             }
                         ],
-                        "browser": "src/main.ts",
+                        "browser": "apps/web/src/main.ts",
                         "inlineStyleLanguage": "scss",
+                        "outputPath": {
+                            "base": "apps/web/dist"
+                        },
                         "sourceMap": true,
-                        "styles": ["src/styles.scss"],
-                        "tsConfig": "tsconfig.app.json"
+                        "styles": ["apps/web/src/styles.scss"],
+                        "tsConfig": "apps/web/tsconfig.app.json"
                     },
                     "defaultConfiguration": "production",
                     "configurations": {

--- a/apps/web/.postcssrc.json
+++ b/apps/web/.postcssrc.json
@@ -1,0 +1,5 @@
+{
+    "plugins": {
+        "@tailwindcss/postcss": {}
+    }
+}

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -17,9 +17,9 @@ pnpm moon run web:build   # production build to dist/web
 
 ## Notable choices
 
-- Self-contained Angular CLI workspace (its own `angular.json`), not a project inside a shared root workspace — see [ADR-0012](../../docs/adr/0012-self-contained-angular-workspace-per-app.md).
+- A project in the shared root `angular.json` workspace, not a self-contained Angular CLI workspace of its own — see [ADR-0020](../../docs/adr/0020-root-level-angular-workspace.md), superseding [ADR-0012](../../docs/adr/0012-self-contained-angular-workspace-per-app.md).
 - Zoneless change detection, and Vitest (not Karma/Jasmine) as the test runner — see [ADR-0013](../../docs/adr/0013-zoneless-vitest-testing-stack.md).
-- `@angular/*` dependencies and `typescript` are version-pinned via the workspace root's `catalog:angular` pnpm catalog, not directly in this package's `package.json`.
+- `@angular/core`, `@angular/platform-browser`, `@angular/router`, and the Angular CLI toolchain (`@angular/build`, `@angular/cli`, `@angular/compiler-cli`) are declared in the workspace root's `package.json` instead of here, so the root `angular.json` resolves a single version. The remaining `@angular/*` packages and `typescript` are still pinned directly in this package's `package.json`, via the workspace root's `catalog:angular` pnpm catalog.
 
 ## Status
 

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -17,9 +17,9 @@ tasks:
         command: 'ng build'
         toolchains: ['node']
         inputs:
+            - '/angular.json'
             - 'src/**/*'
             - 'public/**/*'
-            - 'angular.json'
             - 'tsconfig*.json'
         outputs:
             - 'dist'

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,10 @@
     "@angular/build": "catalog:angular",
     "@angular/cli": "catalog:angular",
     "@angular/compiler-cli": "catalog:angular",
+    "@tailwindcss/postcss": "~4.3.2",
     "jsdom": "^28.0.0",
+    "postcss": "~8.5.16",
+    "tailwindcss": "~4.3.2",
     "typescript": "catalog:angular",
     "vitest": "~4.1.9"
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,17 +5,11 @@
   "dependencies": {
     "@angular/common": "catalog:angular",
     "@angular/compiler": "catalog:angular",
-    "@angular/core": "catalog:angular",
     "@angular/forms": "catalog:angular",
-    "@angular/platform-browser": "catalog:angular",
-    "@angular/router": "catalog:angular",
     "rxjs": "~7.8.2",
     "tslib": "~2.8.1"
   },
   "devDependencies": {
-    "@angular/build": "catalog:angular",
-    "@angular/cli": "catalog:angular",
-    "@angular/compiler-cli": "catalog:angular",
     "@tailwindcss/postcss": "~4.3.2",
     "jsdom": "^28.0.0",
     "postcss": "~8.5.16",

--- a/apps/web/src/core/root/root.ts
+++ b/apps/web/src/core/root/root.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
 @Component({
-    selector: 'app-root',
+    selector: 'web-root',
     templateUrl: './root.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [RouterOutlet],

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -8,6 +8,6 @@
         <link rel="icon" type="image/x-icon" href="favicon.ico" />
     </head>
     <body>
-        <app-root></app-root>
+        <web-root></web-root>
     </body>
 </html>

--- a/apps/web/src/styles.scss
+++ b/apps/web/src/styles.scss
@@ -1,1 +1,2 @@
 /* You can add global styles to this file, and also import other style files */
+@use 'tailwindcss';

--- a/docs/adr/0012-self-contained-angular-workspace-per-app.md
+++ b/docs/adr/0012-self-contained-angular-workspace-per-app.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: superseded by ADR-0020
 ---
 
 # Self-contained Angular CLI workspace per app, not a shared root `angular.json`

--- a/docs/adr/0020-root-level-angular-workspace.md
+++ b/docs/adr/0020-root-level-angular-workspace.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+---
+
+# Root-level `angular.json` workspace, superseding per-app self-containment
+
+[ADR-0012](./0012-self-contained-angular-workspace-per-app.md) gave every Angular app its own `angular.json` specifically to keep moon as the sole multi-project build graph. In practice this also means Angular-CLI-native tooling only ever sees one app at a time: the Angular CLI MCP server ([angular.dev/ai/mcp](https://angular.dev/ai/mcp)) is fixed to whichever workspace directory it's started in for most of its tools (`list_projects`, `run_target`, `devserver.*`), so a second self-contained app would need its own, separately registered MCP server; and `ng generate` can only scaffold into the one workspace it's run from. We're reversing that call: `angular.json` moves to the repo root and lists every Angular app/lib as a project, so one Angular CLI MCP server registration and one `ng generate` invocation point work across all of them, present and future. The `@angular/*` packages and `typescript` needed to resolve the root `angular.json` (`@angular/core`, `@angular/platform-browser`, `@angular/router`, `@angular/build`, `@angular/cli`, `@angular/compiler-cli`) move to the root `package.json`, resolved via `catalog:angular` ([ADR-0011](./0011-per-framework-typescript-catalogs.md)) except `@angular/core`, pinned directly instead: the Angular CLI MCP server reads that dependency's version string straight out of `package.json` to detect the framework version, and can't parse a `catalog:` reference (see [docs/agents/mcp-servers.md](../agents/mcp-servers.md)).
+
+## Consequences
+
+- Supersedes [ADR-0012](./0012-self-contained-angular-workspace-per-app.md); accepts the exact trade-off that ADR warned about — Angular CLI's own project registry now runs as a second, framework-owned multi-project graph alongside moon's per-app task graph.
+- Moon remains the task orchestrator: `build`/`start`/`test` etc. are still defined per app in each app's `moon.yml` and still shell out to `ng`; only project *discovery* (`angular.json`) and cross-cutting Angular-CLI tooling (`ng generate`, the MCP server) move to the workspace root.
+- `.mcp.json` registers the Angular CLI MCP server once, running from the workspace root, instead of one entry per app.
+- `@angular/core` is the one exception to [ADR-0011](./0011-per-framework-typescript-catalogs.md)'s catalog pattern, to keep the MCP server's version detection working; a future contributor bumping Angular versions must update it in two places (`pnpm-workspace.yaml`'s `catalog:angular` and `package.json`'s pinned entry) instead of one.

--- a/docs/agents/mcp-servers.md
+++ b/docs/agents/mcp-servers.md
@@ -1,0 +1,21 @@
+# MCP Servers
+
+`.mcp.json` at the repo root registers these MCP servers for AI coding assistants (e.g., Claude Code). No extra setup is required beyond `pnpm install`.
+
+## moon
+
+Registered as `moon`, running `pnpm moon mcp`. Lets the assistant query the project/task graph directly (`get_project`, `get_tasks`, `get_changed_files`, etc.) instead of shelling out to `moon` commands.
+
+## angular-cli
+
+Registered as `angular-cli`, running `pnpm ng mcp` from the workspace root. Covers the shared root `angular.json` ([ADR-0020](../adr/0020-root-level-angular-workspace.md)) and every Angular app/lib registered in it. Exposes tools such as `list_projects`, `get_best_practices`, `run_target`, `devserver.start`/`stop`/`wait_for_build`, `search_documentation`, and `onpush_zoneless_migration`; see [angular.dev/ai/mcp](https://angular.dev/ai/mcp) for the full tool list.
+
+**Known issue (Windows):** tools that accept a workspace/file path parameter hang indefinitely (no response, no error) when given a native Windows backslash path, confirmed with `get_best_practices`'s `workspacePath` argument, even though `list_projects` itself returns paths in that backslash form. Forward-slash paths (e.g. `D:/repo/path` instead of `D:\repo\path`) work correctly. Pass forward-slash paths as a workaround on Windows.
+
+Searched `angular/angular-cli` upstream for an existing report or fix; found related-but-distinct Windows/path-handling issues in the MCP server, but nothing matching this exact symptom (silent, indefinite hang with no error/timeout, on a syntactically valid Windows path):
+
+- [#32407](https://github.com/angular/angular-cli/issues/32407) — MCP-invoked `ng` commands (e.g. `modernize`, `build`) fail outright on Windows with `spawn ng ENOENT`; attributed to `spawn` not resolving the executable when the `shell` option is `false`. Different failure modes (explicit error vs. silent hang) but the same underlying theme: the MCP server's process/path handling is fragile on Windows. Open, unresolved, no linked PR as of `@angular/cli@21.1.2`.
+- [#32130](https://github.com/angular/angular-cli/issues/32130) — inconsistent MCP tool behavior with a mangled path in the error output (`scandir '/home/user/some_system_drive/V:/XSD'`), suggesting path-resolution bugs elsewhere in the same tool layer. Reported on Linux, not Windows, and errors visibly rather than hanging. Open, unresolved, on Angular CLI 21.0.3.
+- [#30855](https://github.com/angular/angular-cli/issues/30855) — MCP couldn't discover `angular.json` in monorepo subfolders (only checked the repo root). Closed, fixed via [#31067](https://github.com/angular/angular-cli/pull/31067). Not our root-level setup, but confirms workspace/path discovery in this server has had bugs before.
+
+No existing issue or fix found for our specific case as of `@angular/cli@22.0.5`. If this becomes a recurring annoyance, file a new issue upstream with a minimal repro (a `get_best_practices` call with a Windows backslash `workspacePath` that never returns) rather than assuming one of the above covers it.

--- a/docs/guides/game/medieval-dynasty-starting-village-settlement-guide.html
+++ b/docs/guides/game/medieval-dynasty-starting-village-settlement-guide.html
@@ -603,7 +603,7 @@
                     ><span>Hunting Lodge worker</span>
                 </div>
 
-                <div class="grid three">
+                <div class="three grid">
                     <article class="card">
                         <span class="tag">Villager 1</span>
                         <h3>Lumberjack</h3>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "husky": "catalog:tooling",
     "lint-staged": "catalog:tooling",
     "prettier": "catalog:tooling",
-    "prettier-plugin-organize-imports": "catalog:tooling"
+    "prettier-plugin-organize-imports": "catalog:tooling",
+    "prettier-plugin-tailwindcss": "catalog:tooling"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,15 @@
   "scripts": {
     "prepare": "husky"
   },
+  "dependencies": {
+    "@angular/core": "~22.0.5",
+    "@angular/platform-browser": "catalog:angular",
+    "@angular/router": "catalog:angular"
+  },
   "devDependencies": {
+    "@angular/build": "catalog:angular",
+    "@angular/cli": "catalog:angular",
+    "@angular/compiler-cli": "catalog:angular",
     "@commitlint/cli": "catalog:tooling",
     "@commitlint/config-conventional": "catalog:tooling",
     "@moonrepo/cli": "catalog:tooling",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,22 +313,31 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: catalog:angular
-        version: 22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)))(@types/node@26.1.0)(chokidar@5.0.0)(jiti@2.6.1)(postcss@8.5.16)(tslib@2.8.1)(typescript@6.0.3)(vitest@4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0)))(yaml@2.9.0)
+        version: 22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)))(@types/node@26.1.0)(chokidar@5.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.16)(tailwindcss@4.3.2)(tslib@2.8.1)(typescript@6.0.3)(vitest@4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0)))(yaml@2.9.0)
       '@angular/cli':
         specifier: catalog:angular
         version: 22.0.5(@types/node@26.1.0)(chokidar@5.0.0)
       '@angular/compiler-cli':
         specifier: catalog:angular
         version: 22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3)
+      '@tailwindcss/postcss':
+        specifier: ~4.3.2
+        version: 4.3.2
       jsdom:
         specifier: ^28.0.0
         version: 28.1.0
+      postcss:
+        specifier: ~8.5.16
+        version: 8.5.16
+      tailwindcss:
+        specifier: ~4.3.2
+        version: 4.3.2
       typescript:
         specifier: catalog:angular
         version: 6.0.3
       vitest:
         specifier: ~4.1.9
-        version: 4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0))
 
   packages/tsconfig: {}
 
@@ -392,6 +401,10 @@ packages:
   '@algolia/requester-node-http@5.52.0':
     resolution: {integrity: sha512-gyyWcLD22tnabmoit4iukCXuoRc5HYJuUjPSEa8a0D/f/NlRafpWi52AlAaa4Uu/rsl7saHsJFTNjTptWbu2+A==}
     engines: {node: '>= 14.0.0'}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1930,6 +1943,98 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tailwindcss/node@4.3.2':
+    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.2':
+    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.3.2':
+    resolution: {integrity: sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==}
+
   '@tufjs/canonical-json@2.0.0':
     resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -2275,6 +2380,10 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -2581,6 +2690,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
@@ -2629,6 +2742,80 @@ packages:
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -3166,6 +3353,13 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   tar@7.5.19:
     resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
@@ -3520,6 +3714,8 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.52.0
 
+  '@alloc/quick-lru@5.2.0': {}
+
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -3553,7 +3749,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)))(@types/node@26.1.0)(chokidar@5.0.0)(jiti@2.6.1)(postcss@8.5.16)(tslib@2.8.1)(typescript@6.0.3)(vitest@4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0)))(yaml@2.9.0)':
+  '@angular/build@22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)))(@types/node@26.1.0)(chokidar@5.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.16)(tailwindcss@4.3.2)(tslib@2.8.1)(typescript@6.0.3)(vitest@4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0)))(yaml@2.9.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2200.5(chokidar@5.0.0)
@@ -3563,7 +3759,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 6.0.12(@types/node@26.1.0)
-      '@vitejs/plugin-basic-ssl': 2.3.0(vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0))
+      '@vitejs/plugin-basic-ssl': 2.3.0(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0))
       beasties: 0.4.2
       browserslist: 4.28.4
       esbuild: 0.28.1
@@ -3582,14 +3778,15 @@ snapshots:
       tinyglobby: 0.2.16
       tslib: 2.8.1
       typescript: 6.0.3
-      vite: 7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0)
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)
       '@angular/platform-browser': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))
       lmdb: 3.5.4
       postcss: 8.5.16
-      vitest: 4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0))
+      tailwindcss: 4.3.2
+      vitest: 4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -4796,6 +4993,75 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tailwindcss/node@4.3.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.2
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-x64': 4.3.2
+      '@tailwindcss/oxide-freebsd-x64': 4.3.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
+
+  '@tailwindcss/postcss@4.3.2':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
+      postcss: 8.5.16
+      tailwindcss: 4.3.2
+
   '@tufjs/canonical-json@2.0.0': {}
 
   '@tufjs/models@4.1.0':
@@ -4818,9 +5084,9 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
-  '@vitejs/plugin-basic-ssl@2.3.0(vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0))':
+  '@vitejs/plugin-basic-ssl@2.3.0(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0))':
     dependencies:
-      vite: 7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -4831,13 +5097,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -5154,6 +5420,11 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   encodeurl@2.0.0: {}
+
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   entities@4.5.0: {}
 
@@ -5500,6 +5771,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jiti@2.7.0: {}
+
   jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
@@ -5550,6 +5823,55 @@ snapshots:
   jsonc-parser@3.3.1: {}
 
   jsonparse@1.3.1: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lines-and-columns@1.2.4: {}
 
@@ -6210,6 +6532,10 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tailwindcss@4.3.2: {}
+
+  tapable@2.3.3: {}
+
   tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -6286,7 +6612,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0):
+  vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6297,14 +6623,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.0
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
+      lightningcss: 1.32.0
       sass: 1.99.0
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -6321,7 +6648,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@26.1.0)(jiti@2.6.1)(sass@1.99.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ catalogs:
     prettier-plugin-organize-imports:
       specifier: ~4.3.0
       version: 4.3.0
+    prettier-plugin-tailwindcss:
+      specifier: ~0.8.0
+      version: 0.8.0
 
 importers:
 
@@ -283,6 +286,9 @@ importers:
       prettier-plugin-organize-imports:
         specifier: catalog:tooling
         version: 4.3.0(prettier@3.9.4)(typescript@6.0.3)
+      prettier-plugin-tailwindcss:
+        specifier: catalog:tooling
+        version: 0.8.0(prettier-plugin-organize-imports@4.3.0(prettier@3.9.4)(typescript@6.0.3))(prettier@3.9.4)
 
   apps/web:
     dependencies:
@@ -3122,6 +3128,61 @@ packages:
       vue-tsc: ^2.1.0 || 3
     peerDependenciesMeta:
       vue-tsc:
+        optional: true
+
+  prettier-plugin-tailwindcss@0.8.0:
+    resolution: {integrity: sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-svelte:
         optional: true
 
   prettier@3.9.4:
@@ -6239,6 +6300,12 @@ snapshots:
     dependencies:
       prettier: 3.9.4
       typescript: 6.0.3
+
+  prettier-plugin-tailwindcss@0.8.0(prettier-plugin-organize-imports@4.3.0(prettier@3.9.4)(typescript@6.0.3))(prettier@3.9.4):
+    dependencies:
+      prettier: 3.9.4
+    optionalDependencies:
+      prettier-plugin-organize-imports: 4.3.0(prettier@3.9.4)(typescript@6.0.3)
 
   prettier@3.9.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,9 +220,6 @@ catalogs:
     '@angular/compiler-cli':
       specifier: ~22.0.5
       version: 22.0.5
-    '@angular/core':
-      specifier: ~22.0.5
-      version: 22.0.5
     '@angular/forms':
       specifier: ~22.0.5
       version: 22.0.5
@@ -264,7 +261,26 @@ catalogs:
 importers:
 
   .:
+    dependencies:
+      '@angular/core':
+        specifier: ~22.0.5
+        version: 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)
+      '@angular/platform-browser':
+        specifier: catalog:angular
+        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))
+      '@angular/router':
+        specifier: catalog:angular
+        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)))(rxjs@7.8.2)
     devDependencies:
+      '@angular/build':
+        specifier: catalog:angular
+        version: 22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)))(@types/node@26.1.0)(chokidar@5.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.16)(tailwindcss@4.3.2)(tslib@2.8.1)(typescript@6.0.3)(vitest@4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0)))(yaml@2.9.0)
+      '@angular/cli':
+        specifier: catalog:angular
+        version: 22.0.5(@types/node@26.1.0)(chokidar@5.0.0)
+      '@angular/compiler-cli':
+        specifier: catalog:angular
+        version: 22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3)
       '@commitlint/cli':
         specifier: catalog:tooling
         version: 21.2.0(@types/node@26.1.0)(typescript@6.0.3)
@@ -298,16 +314,7 @@ importers:
       '@angular/compiler':
         specifier: catalog:angular
         version: 22.0.5
-      '@angular/core':
-        specifier: catalog:angular
-        version: 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)
       '@angular/forms':
-        specifier: catalog:angular
-        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)))(rxjs@7.8.2)
-      '@angular/platform-browser':
-        specifier: catalog:angular
-        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))
-      '@angular/router':
         specifier: catalog:angular
         version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)))(rxjs@7.8.2)
       rxjs:
@@ -317,15 +324,6 @@ importers:
         specifier: ~2.8.1
         version: 2.8.1
     devDependencies:
-      '@angular/build':
-        specifier: catalog:angular
-        version: 22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)))(@types/node@26.1.0)(chokidar@5.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.16)(tailwindcss@4.3.2)(tslib@2.8.1)(typescript@6.0.3)(vitest@4.1.9(@types/node@26.1.0)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(yaml@2.9.0)))(yaml@2.9.0)
-      '@angular/cli':
-        specifier: catalog:angular
-        version: 22.0.5(@types/node@26.1.0)(chokidar@5.0.0)
-      '@angular/compiler-cli':
-        specifier: catalog:angular
-        version: 22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3)
       '@tailwindcss/postcss':
         specifier: ~4.3.2
         version: 4.3.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ catalogs:
         'lint-staged': '~17.0.8'
         'prettier': '~3.9.4'
         'prettier-plugin-organize-imports': '~4.3.0'
+        'prettier-plugin-tailwindcss': '~0.8.0'
 
 savePrefix: '~'
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,6 @@ catalogs:
         '@angular/common': '~22.0.5'
         '@angular/compiler': '~22.0.5'
         '@angular/compiler-cli': '~22.0.5'
-        '@angular/core': '~22.0.5'
         '@angular/forms': '~22.0.5'
         '@angular/platform-browser': '~22.0.5'
         '@angular/router': '~22.0.5'


### PR DESCRIPTION
## What

Adds Tailwind v4 (utility-first, SCSS `@use`) to `apps/web` per ADR-0014, and restructures the Angular CLI workspace to a single root-level `angular.json` (ADR-0020, superseding ADR-0012). Also registers and documents an Angular CLI MCP server for AI coding assistants alongside the existing moon one.

## Why

Phase 2 of the `apps/web` scaffold plan called for Tailwind. Separately, wiring up the Angular CLI's MCP server surfaced that a self-contained per-app `angular.json` (ADR-0012) would require one MCP server registration per Angular app going forward. Consolidating to a single root-level `angular.json` lets one MCP registration and one `ng generate` invocation cover every current and future Angular app/lib. That in turn required moving some `@angular/*` dependencies to the root `package.json` and pinning `@angular/core`'s version directly, instead of via the `catalog:angular` pnpm catalog, because the MCP server's version-detection code can't parse a catalog reference.

## How to Review

Start with the two Tailwind commits (`feat(web)`, `build(prettier)`), which are self-contained. Then `refactor(angular)` is the core structural change (moving `angular.json` to the root); `docs(web)`, `fix(web)`, `chore(mcp)`, and `docs(agents)` build on top of it. `docs/agents/mcp-servers.md` documents a known Windows-specific bug found in the Angular CLI MCP server; safe to skim if you're not on Windows.

## Testing

- [x] `pnpm moon ci` passes locally
- [x] Manually verified: `pnpm moon run web:build` and `pnpm moon run web:start` produce Tailwind-styled output; `pnpm moon run root:format` sorts Tailwind classes; the Angular CLI MCP server (`pnpm ng mcp`) starts and `list_projects` correctly reports the `web` project with a resolved framework version

## Deployment Notes

None.