### PR TITLE
Containerize `web` with Docker

### DIFF
--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1
+#
+# Build context is the repo root, not .docker/web:
+#   docker build -f .docker/web/Dockerfile -t craftsmans-ledger-web .
+#
+# See docs/adr/0025-moon-docker-scaffold-pattern-for-web-image.md and
+# docs/adr/0026-rootless-nginx-runtime-for-web.md for the rationale behind
+# this stage layout.
+
+#### BASE
+FROM node:24.18.0-alpine AS base
+
+WORKDIR /app
+
+RUN apk add --no-cache git
+
+RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
+
+RUN pnpm add -g @moonrepo/cli@2.3.5
+
+
+#### SKELETON
+FROM base AS skeleton
+
+COPY . .
+
+RUN moon docker scaffold web
+
+
+#### BUILD
+FROM base AS build
+
+COPY --from=skeleton /app/.moon/docker/configs .
+
+RUN moon docker setup
+
+COPY --from=skeleton /app/.moon/docker/sources .
+
+COPY --from=skeleton /app/angular.json .
+
+RUN moon run web:build
+
+
+#### RUNTIME
+FROM nginx:1.29-alpine AS runtime
+
+COPY .docker/web/default.conf /etc/nginx/conf.d/default.conf
+
+COPY --from=build /app/apps/web/dist/browser /usr/share/nginx/html
+
+RUN chown -R nginx:nginx /var/cache/nginx /run /usr/share/nginx/html
+
+USER nginx
+
+EXPOSE 8080
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -8,7 +8,7 @@
 # this stage layout.
 
 #### BASE
-FROM node:24.18.0-alpine AS base
+FROM node:24.18.0-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS base
 
 WORKDIR /app
 
@@ -45,7 +45,7 @@ RUN moon run web:build
 
 
 #### RUNTIME
-FROM nginx:1.29-alpine AS runtime
+FROM nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de AS runtime
 
 COPY .docker/web/default.conf /etc/nginx/conf.d/default.conf
 

--- a/.docker/web/default.conf
+++ b/.docker/web/default.conf
@@ -1,0 +1,15 @@
+# Overrides only nginx:1.29-alpine's default server block (included from the
+# base image's own /etc/nginx/nginx.conf via `include /etc/nginx/conf.d/*.conf`,
+# left untouched so we keep its mime types, log format, sendfile, etc.):
+# unprivileged port 8080 (rootless nginx can't bind 80) and SPA fallback
+# routing.
+server {
+    listen 8080;
+    server_name _;
+    root  /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,9 +8,21 @@ node_modules/
 
 # Build/test output — regenerated inside the image, or irrelevant to it.
 dist/
+out-tsc/
+tmp/
 coverage/
 reports/
 .angular/
+*.log
 
 .idea/
 .vscode/
+
+# Never let host-local secrets into the build context/layer cache.
+.env
+.env.*.local
+
+# Not needed by moon's project-scoped scaffold of any app.
+.github/
+.claude/
+docs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# moon docker scaffold rebuilds dependencies inside the image; host-platform
+# node_modules and moon's local cache would be both wrong and non-portable.
+node_modules/
+.moon/cache/
+.moon/docker/
+
+.git/
+
+# Build/test output — regenerated inside the image, or irrelevant to it.
+dist/
+coverage/
+reports/
+.angular/
+
+.idea/
+.vscode/

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -20,6 +20,17 @@ pnpm moon run web:lint-css    # Stylelint
 pnpm moon run web:typecheck   # tsc --noEmit across the app, spec, and eslint tsconfigs
 ```
 
+## Docker
+
+`web` is a static build served by nginx once containerized; there's no moon task for this (see [ADR-0027](../../docs/adr/0027-web-dockerfile-scope-excludes-ci-publishing.md)), so build and run it directly from the repo root:
+
+```bash
+docker build -f .docker/web/Dockerfile -t craftsmans-ledger-web .
+docker run --rm -p 8080:8080 craftsmans-ledger-web   # http://localhost:8080
+```
+
+See [ADR-0025](../../docs/adr/0025-moon-docker-scaffold-pattern-for-web-image.md) and [ADR-0026](../../docs/adr/0026-rootless-nginx-runtime-for-web.md) for the image's build pattern and rootless runtime.
+
 ## Notable choices
 
 - A project in the shared root `angular.json` workspace, not a self-contained Angular CLI workspace of its own — see [ADR-0020](../../docs/adr/0020-root-level-angular-workspace.md), superseding [ADR-0012](../../docs/adr/0012-self-contained-angular-workspace-per-app.md).

--- a/docs/adr/0025-moon-docker-scaffold-pattern-for-web-image.md
+++ b/docs/adr/0025-moon-docker-scaffold-pattern-for-web-image.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+---
+
+# moon's docker scaffold/setup pattern for `web`'s image build, skipping `prune`
+
+`.docker/web/Dockerfile` (#92) builds its `BUILD` stage using moon's native Docker integration (`moon docker scaffold web` → `moon docker setup` → `moon run web:build`, per [moonrepo's Docker guide](https://moonrepo.dev/docs/guides/docker)) rather than a hand-rolled `pnpm install --frozen-lockfile` + `pnpm --filter web build`. `scaffold` extracts only the manifests/lockfiles needed for `web`'s dependency graph before the full source is copied in, giving Docker layer caching that survives changes to unrelated packages — consistent with this repo's existing preference for a tool's native mechanism over a generic workaround (see [ADR-0007](./0007-ci-toolchain-via-setup-node-pnpm-action-setup.md)). The `BASE`/`SKELETON`/`BUILD` stages pin `node:24.18.0-alpine`, matching the exact Node version mise/`package.json` already treat as authoritative ([ADR-0002](./0002-mise-as-sole-toolchain-version-authority.md)), and install `@moonrepo/cli@2.3.5` to match the workspace's own `catalog:tooling` pin.
+
+The guide's documented pattern ends with `moon docker prune` (strips `node_modules` down to production-only, project-scoped deps) before the runtime stage copies files out of `BUILD`. This Dockerfile skips it: the runtime stage ([ADR-0026](./0026-rootless-nginx-runtime-for-web.md)) only ever `COPY --from=build`s the static `apps/web/dist/browser` output, never `node_modules`, so pruning has no effect on the shipped image and would only add build time.
+
+## Consequences
+
+- If a future app in this monorepo ships a Node runtime (not a static build served by nginx), its Dockerfile should reinstate `moon docker prune` before the runtime stage, since in that case the pruned `node_modules` *would* ship.
+- `moon docker scaffold web` is project-scoped and doesn't know about the root-level `angular.json` that [ADR-0020](./0020-root-level-angular-workspace.md) moved out of `apps/web` — `ng build` fails with "not available outside a workspace" without it. The `BUILD` stage copies `angular.json` from the `SKELETON` stage's full source checkout as an explicit extra step, alongside the scaffolded `sources`. A future app added to the root `angular.json` workspace needs the same extra `COPY` in its own Dockerfile.
+- `node:24.18.0-alpine` ships neither `git` nor a `pnpm` binary; the `BASE` stage installs `git` via `apk` (moon shells out to it even during `docker setup`) and activates `pnpm@11.9.0` via `corepack enable && corepack prepare pnpm@11.9.0 --activate`, matching `package.json`'s `devEngines.packageManager` pin — `moon docker setup` itself runs `pnpm install` directly rather than provisioning `pnpm` on its own.
+- `@moonrepo/cli` is installed via `pnpm add -g`, not `npm install -g` (the pattern moonrepo's own Docker guide uses) — `npm` would be inconsistent with this repo treating `pnpm` as the sole package manager ([ADR-0001](./0001-moonrepo-mise-pnpm-for-monorepo-tooling.md)). Unlike `npm`, `pnpm`'s global installs need an explicit global bin directory on `PATH` (`pnpm add -g` fails with "global bin directory ... is not in PATH" otherwise) — the `BASE` stage sets `PNPM_HOME=/pnpm` and prepends `$PNPM_HOME:$PNPM_HOME/bin` to `PATH` before installing moon.

--- a/docs/adr/0026-rootless-nginx-runtime-for-web.md
+++ b/docs/adr/0026-rootless-nginx-runtime-for-web.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Rootless `nginx:1.29-alpine` runtime for `web`, not `nginx-unprivileged`
+
+`apps/web`'s image (#92) is a pure client-side build — `angular.json`'s `web` project has no `server.ts`/SSR builder, just `@angular/build:application` emitting static assets to `apps/web/dist/browser` — so the runtime stage only needs a static file server, not a Node process. `nginx:1.29-alpine` was chosen over Caddy or a Node-based static server (e.g. `serve`) as the conventional, minimal-footprint choice for serving a production SPA build.
+
+Rather than basing the runtime stage on `nginxinc/nginx-unprivileged`, it's built rootless on top of the standard `nginx:1.29-alpine` image directly: the Dockerfile `chown`s `/var/cache/nginx`, `/run` (where the base image's own, untouched `nginx.conf` already points its `pid` directive), and the copied `html` directory to the built-in `nginx` user, then switches to it via `USER nginx` before `CMD`. This stays on the far more common `nginx:alpine` base — better documented, more likely to already be familiar to whoever maintains this next — instead of a smaller, less-used unprivileged variant, at the cost of a couple of extra Dockerfile lines to do the hardening by hand.
+
+`.docker/web/default.conf` overrides only `/etc/nginx/conf.d/default.conf` — the base image's `/etc/nginx/nginx.conf` is left untouched and still `include`s it, so its mime types, log format, `sendfile`, and `keepalive_timeout` defaults keep coming from upstream instead of being hand-duplicated and drifting over time. `default.conf` only changes what actually needs to change for this setup: the unprivileged listen port 8080, and SPA client-side routing via `try_files $uri $uri/ /index.html;`. Running as non-root means nginx logs one harmless startup warning ("the 'user' directive makes sense only if the master process runs with super-user privileges, ignored") since the base `nginx.conf`'s `user nginx;` line is now moot — expected and standard for any stock nginx image run rootless, not worth suppressing by overriding the whole file just to drop one line.
+
+## Consequences
+
+- Anything running this container (a `docker run -p`, a compose file, a future orchestrator manifest) must map to container port 8080, not 80.
+- If `web` grows an SSR build later, this ADR's runtime-stage choice (nginx serving a static build) no longer applies and needs revisiting alongside that change.
+- A future change to this repo's nginx setup (e.g., adding gzip, custom headers) belongs in `.docker/web/default.conf`'s `server` block, not a reintroduced full `nginx.conf` override — keep inheriting the base image's top-level defaults.

--- a/docs/adr/0027-web-dockerfile-scope-excludes-ci-publishing.md
+++ b/docs/adr/0027-web-dockerfile-scope-excludes-ci-publishing.md
@@ -1,0 +1,12 @@
+---
+status: accepted
+---
+
+# `web`'s Dockerfile ships without CI builds or registry publishing
+
+#92 asked only to containerize `web`; no deployment target or container registry has been chosen anywhere in this repo yet. `.docker/web/Dockerfile` and `.docker/web/default.conf` are added for local/manual builds (`docker build -f .docker/web/Dockerfile -t craftsmans-ledger-web .`) only — neither `.github/workflows/pull-request.yml` nor `push-main.yml` build or push the image. Building it in CI now, with nothing to deploy it to yet, it would be scope creep the issue didn't ask for and premature given the registry/target is still undecided.
+
+## Consequences
+
+- CI does not currently catch a broken Dockerfile; a `docker build` failure would only surface when someone builds it locally.
+- Wiring CI (build-only, or build-and-push once a registry/target is chosen) is deferred to a follow-up issue.

--- a/docs/adr/0028-top-level-docker-folder-per-app.md
+++ b/docs/adr/0028-top-level-docker-folder-per-app.md
@@ -1,0 +1,12 @@
+---
+status: accepted
+---
+
+# Docker files live under top-level `.docker/<app>/`, not co-located with the app
+
+`web`'s container definition (#92) was first added as `apps/web/Dockerfile` and `apps/web/nginx.conf`, alongside the app's other self-owned config (`moon.yml`, `eslint.config.mts`, `.stylelintrc.json`, etc.). It moved to `.docker/web/Dockerfile` and `.docker/web/default.conf` — a deliberate deviation from that co-location convention: as more apps/services in this monorepo need containerizing, `.docker/<name>/` keeps every container definition discoverable from one top-level location instead of scattered across `apps/*`, and keeps app directories free of infra-specific concerns that aren't part of the app's own build/test/lint surface. The Docker build context stays the repo root either way (moon's project-scoped scaffold, [ADR-0025](./0025-moon-docker-scaffold-pattern-for-web-image.md), needs the whole workspace visible regardless of where the Dockerfile itself lives), so this only affects `-f` path and file location, not the build's mechanics.
+
+## Consequences
+
+- A future app's container files go in `.docker/<app-name>/`, not `apps/<app-name>/`.
+- `docker build` invocations reference `-f .docker/<app>/Dockerfile`, documented per-app in that app's own README (e.g. `apps/web/README.md`).


### PR DESCRIPTION
## What

Adds a multi-stage `Dockerfile` under `.docker/web` that builds `web`'s production Angular bundle via moon's native Docker integration and serves it from a rootless `nginx:1.29-alpine` runtime on port 8080. Also adds four ADRs documenting the build pattern, the rootless nginx setup, the CI scope decision, and the `.docker/<app>/` file-placement convention, plus a Docker section in `apps/web/README.md` with build/run commands.

## Why

Closes #92. `web` needs a reproducible, deployable container image. No deployment target or registry has been chosen yet, so this is scoped to the Dockerfile and local/manual builds only — CI build/publish is deliberately deferred (see ADR-0027).

## How to Review

Start with `.docker/web/Dockerfile` stage by stage (`BASE` → `SKELETON` → `BUILD` → `RUNTIME`). Cross-check the `BUILD` stage against ADR-0025 for why it uses moon's `docker scaffold`/`setup` instead of a hand-rolled `pnpm install`, and the `RUNTIME` stage against ADR-0026 for why it overrides only nginx's default server block instead of the whole `nginx.conf`. ADR-0028 explains why these files live under top-level `.docker/web/` instead of `apps/web/`.

## Testing

- [x] `pnpm moon ci` passes locally
- [x] Manually verified: built and ran the image locally (`docker build -f .docker/web/Dockerfile -t craftsmans-ledger-web .` then `docker run --rm -p 8080:8080 craftsmans-ledger-web`), confirmed `200` responses on both `/` and a deep SPA route, and confirmed the container runs as the non-root `nginx` user.

## Deployment Notes

None. This PR only adds the Dockerfile for local/manual builds; CI wiring and an actual deployment target are deferred to a follow-up (ADR-0027).
