### PR TITLE
fix(ci): Checkout repository in docker-promote job

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -49,6 +49,9 @@ jobs:
             packages: write
             pull-requests: read
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
             - name: Resolve merged PR number
               id: pr
               shell: bash


### PR DESCRIPTION
## What

Adds a missing `Checkout repository` step to the `docker-promote` job in `push-main.yml`, right before the `Docker setup` step that uses the local `./.github/actions/docker` composite action.

## Why

The `docker-promote` job never checked out the repository, so on a fresh runner there was no `.github/actions/docker/action.yml` for the composite action to load. This made the `Promote Docker image` job fail on every push to `main` with "Can't find 'action.yml' ... Did you forget to run actions/checkout". The analogous `docker-web` and `e2e-web` jobs in `pull-request.yml` already check out the repo before using local actions, confirming this was an oversight rather than intentional.

## How to Review

Diff is a single 3-line addition in `.github/workflows/push-main.yml`. Compare the `docker-promote` job's step order against `docker-web`/`e2e-web` in `pull-request.yml` to see the pattern being restored.

## Testing

- [x] `pnpm moon ci` passes locally
- [x] Manually verified: not runnable locally (GitHub Actions workflow); will be confirmed on the next merge to `main` when `docker-promote` runs

## Deployment Notes

None.