### PR TITLE
Add Playwright E2E suite for `web`

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -94,6 +94,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  fetch-depth: 0
 
             - name: Setup
               uses: ./.github/actions/setup

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -95,13 +95,24 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+            - name: Setup
+              uses: ./.github/actions/setup
+
             - name: Docker setup
               uses: ./.github/actions/docker
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Start E2E environment
-              run: docker compose -f apps/web/.docker/compose.yaml up -d
+              run: docker compose -f apps/web/.docker/compose.yaml up -d --wait
 
-            - name: Smoke-test E2E environment
-              run: curl --fail -k --retry 5 --retry-delay 1 --retry-all-errors https://localhost:8443/
+            - name: Run E2E suite
+              run: pnpm moon run e2e-web:e2e-ci
+
+            - name: Upload E2E report
+              if: failure()
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: playwright-report
+                  path: e2e/web/playwright-report
+                  retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ desktop.ini
 *.log
 coverage/
 reports/
+test-results/
+playwright-report/
+blob-report/

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -2,6 +2,7 @@ $schema: './cache/schemas/workspace.json'
 projects:
     globs:
         - 'apps/*'
+        - 'e2e/*'
         - 'libs/*'
         - 'packages/*'
     sources:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Early development: repository scaffolding in progress.
 ## Project Structure
 
 - `apps/`: deployable applications
+- `e2e/`: E2E test suites, each targeting one app (e.g. `e2e/web` targets `apps/web`) — not tied to a single testing tool, each suite picks whatever fits its target — see [ADR-0045](docs/adr/0045-e2e-top-level-category-for-e2e-suites.md) for why this is a category of its own rather than living under `apps/`
 - `libs/`: shared *application* code consumed at runtime by `apps/*` (currently empty)
 - `packages/`: shared *build/tooling* config, consumed by name (e.g. `@craftsmans-ledger/tsconfig`), not by relative path
 
@@ -24,6 +25,10 @@ See [ADR-0003](docs/adr/0003-libs-vs-packages-split.md) for the full runtime/bui
 Currently populated apps:
 
 - [`web`](apps/web): the main Angular web client; a project in the shared root `angular.json` workspace ([ADR-0020](docs/adr/0020-root-level-angular-workspace.md)) with zoneless change detection and Vitest as its test runner, see [ADR-0013](docs/adr/0013-zoneless-vitest-testing-stack.md). Currently a shell only: no domain routes/components yet.
+
+Currently populated E2E suites:
+
+- [`e2e-web`](e2e/web): Playwright suite exercising `web` — a boot-smoke spec today, more to follow as `web` grows features. Runs against `web`'s dev server locally, and against the CI-only Compose+Caddy E2E environment in CI; see [ADR-0046](docs/adr/0046-e2e-suite-reuses-existing-servers.md).
 
 Currently populated packages:
 

--- a/apps/web/.docker/compose.yaml
+++ b/apps/web/.docker/compose.yaml
@@ -1,7 +1,11 @@
 # The E2E environment (docs/adr/0039-web-e2e-environment-ci-only-compose-caddy.md):
 # `web`'s image behind a Caddy reverse proxy for HTTPS termination. CI-only —
 # not wired up for local dev use. Invoked from the repo root as:
-#   WEB_IMAGE_TAG=pr-<N> docker compose -f apps/web/.docker/compose.yaml up -d
+#   WEB_IMAGE_TAG=pr-<N> docker compose -f apps/web/.docker/compose.yaml up -d --wait
+#
+# --wait blocks until both services' healthchecks pass, which is what gates the
+# E2E suite (docs/adr/0046-e2e-suite-reuses-existing-servers.md) — no smoke-test
+# step or Playwright-side fallback checks readiness separately.
 #
 # the CI job provides WEB_IMAGE_TAG and WEB_DOCKER_IMAGE.
 
@@ -10,12 +14,23 @@ services:
         image: ${WEB_DOCKER_IMAGE}:${WEB_IMAGE_TAG}
         expose:
             - '8080'
+        healthcheck:
+            test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:8080/']
+            interval: 2s
+            timeout: 2s
+            retries: 10
 
     caddy:
         image: caddy:2-alpine
         depends_on:
-            - web
+            web:
+                condition: service_healthy
         ports:
             - '8443:443'
         volumes:
             - ./Caddyfile:/etc/caddy/Caddyfile:ro
+        healthcheck:
+            test: ['CMD', 'wget', '--spider', '-q', '--no-check-certificate', 'https://localhost/']
+            interval: 2s
+            timeout: 2s
+            retries: 10

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -41,7 +41,11 @@ Every PR touching `web` builds and pushes a multi-platform image to `ghcr.io/<ow
 
 ### E2E environment
 
-`apps/web/.docker/compose.yaml` pairs the just-built `pr-<N>` image with a Caddy reverse proxy for HTTPS termination. It's CI-only — smoke-tested on every PR that touches `web`, but not wired up for local use. See [ADR-0039](../../docs/adr/0039-web-e2e-environment-ci-only-compose-caddy.md).
+`apps/web/.docker/compose.yaml` pairs the just-built `pr-<N>` image with a Caddy reverse proxy for HTTPS termination. It's CI-only, not wired up for local use, and gated by Compose healthchecks (`docker compose up --wait`) rather than a smoke-test step. See [ADR-0039](../../docs/adr/0039-web-e2e-environment-ci-only-compose-caddy.md).
+
+### E2E suite
+
+[`e2e/web`](../../e2e/web) is the Playwright suite that actually exercises `web` — see its own README for commands. In CI it runs against the E2E environment above (`https://localhost:8443`); locally it runs against `web:start`'s dev server instead, reusing an already-running instance if there is one. See [ADR-0046](../../docs/adr/0046-e2e-suite-reuses-existing-servers.md).
 
 ## Notable choices
 
@@ -51,4 +55,4 @@ Every PR touching `web` builds and pushes a multi-platform image to `ghcr.io/<ow
 
 ## Status
 
-Shell only — no domain routes or components yet. Styling (Tailwind + SCSS), shared lint configs, and the full Vitest setup have all landed.
+Shell only — no domain routes or components yet. Styling (Tailwind + SCSS), shared lint configs, the full Vitest setup, and a boot-smoke [E2E suite](../../e2e/web) have all landed.

--- a/docs/adr/0039-web-e2e-environment-ci-only-compose-caddy.md
+++ b/docs/adr/0039-web-e2e-environment-ci-only-compose-caddy.md
@@ -6,7 +6,7 @@ status: accepted
 
 `#95` asks for a Compose stack fronted by Caddy to run E2E tests against `web`'s image — the *E2E environment*, distinct from the *E2E suite* (the Playwright specs themselves, `#94`, still deferred; see [CONTEXT.md](../../CONTEXT.md) for the canonical terms). The environment is pure infrastructure: `web`'s image plus a Caddy reverse proxy for HTTPS termination, with no test runner involved. It lives at `apps/web/.docker/`, alongside the existing `Dockerfile`/`default.conf` and (since [ADR-0043](./0043-per-app-docker-bake-file.md)) `docker-bake.hcl` — nothing under `apps/web/.docker/` is shared with other apps, per [ADR-0042](./0042-per-app-docker-folder-inside-app-directory.md).
 
-The environment is CI-only for now — it isn't wired up for local use. `web`'s local dev HTTPS story (mkcert + hosts-file, [ADR-0029](./0029-local-dev-hostname-convention.md)/[ADR-0030](./0030-web-dev-server-https-only.md)) is unrelated and untouched; Caddy here exists only because CI has no equivalent trusted-local-CA setup. Local reproducibility of the E2E environment is deferred until the E2E suite actually lands and there's a concrete need to run it outside CI.
+The environment is CI-only for now — it isn't wired up for local use. `web`'s local dev HTTPS story (mkcert + hosts-file, [ADR-0029](./0029-local-dev-hostname-convention.md)/[ADR-0030](./0030-web-dev-server-https-only.md)) is unrelated and untouched; Caddy here exists only because CI has no equivalent trusted-local-CA setup. Local reproducibility of the E2E environment is deferred until the E2E suite actually lands, and there's a concrete need to run it outside CI.
 
 Caddy terminates TLS via its own automatic internal HTTPS (`tls internal`) rather than reusing mkcert or hand-rolling an `openssl` cert — zero extra tooling, and mkcert's local-machine trust model buys nothing for a CI-only, ephemeral environment. The smoke-test step that verifies the environment boots uses `curl -k`: its job is to confirm Caddy actually terminates TLS and proxies to `web` correctly, not to validate a publicly trusted cert chain.
 
@@ -18,6 +18,6 @@ There's no explicit `docker compose down` teardown step: `runs-on: ubuntu-24.04`
 
 ## Consequences
 
-- The smoke-test only proves the environment boots and Caddy proxies correctly — it is not a substitute for `#94`'s actual Playwright suite. "Run E2E tests against this image," as `#95` originally asked, isn't fully satisfied until that suite exists.
+- The smoke-test only proved the environment boots and Caddy proxies correctly, as a stand-in until `#94`'s actual Playwright suite existed. [ADR-0046](./0046-e2e-suite-reuses-existing-servers.md) replaces it outright: the `e2e-web` project's `e2e-ci` task now runs in its place, gated by Compose health checks (`docker compose up --wait`) rather than a `curl` retry loop.
 - See [ADR-0040](./0040-dynamic-required-checks-via-skip-as-success.md) for how `docker-web`/`e2e-web` interact with `main`'s required status checks.
-- Whoever picks up `#94` will need to decide how the E2E suite actually reaches the environment (a fresh Compose service running Playwright inside the same network, or something else) — nothing here decides that.
+- How the E2E suite reaches the environment is decided in [ADR-0046](./0046-e2e-suite-reuses-existing-servers.md): the suite runs directly on the CI runner against `https://localhost:8443`, not as a Compose service of its own.

--- a/docs/adr/0045-e2e-top-level-category-for-e2e-suites.md
+++ b/docs/adr/0045-e2e-top-level-category-for-e2e-suites.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# `e2e/` as a new top-level project category, alongside `apps/`, `libs/`, `packages/`
+
+`#94` needed a home for the Playwright *E2E suite* (see [CONTEXT.md](../../CONTEXT.md) for the E2E suite/E2E environment distinction). [ADR-0003](./0003-libs-vs-packages-split.md) had already drawn a two-way line for shared code — `libs/` for shared runtime app code, `packages/` for shared build/lint tooling — and neither fits an E2E suite: it's not shared code at all, it's a standalone, deployable-in-its-own-right test suite that happens to target another project. `apps/e2e-web` was the alternative — reusing the existing `apps/*` glob with zero workspace config changes — but that would stretch `apps/` to mean "top-level project" generally rather than "deployable application" specifically, and more E2E suites (e.g., one for a future API) are expected, making this a repeated pattern rather than a one-off.
+
+`e2e/` is now a first-class category in both `.moon/workspace.yml`'s `projects.globs` and `pnpm-workspace.yaml`'s `packages` list, with `e2e/web/` as its first member (moon project `e2e-web`). Each suite gets its own moon project `id` override — moon's default id-from-folder-name inference would otherwise collide with the app it targets (`e2e/web` and `apps/web` both inferring `web`).
+
+## Consequences
+
+- A future E2E suite for another target follows the same `e2e/<target>/` shape with no further workspace-glob changes needed.
+- `apps/`'s meaning stays strictly "deployable application" — it doesn't have to absorb test-suite projects that aren't deployable artifacts themselves.
+- Anyone extending the `libs/`/`packages/` split from ADR-0003 should read this as a third, orthogonal category (test suites targeting another project), not a rebuttal of ADR-0003's runtime vs. build time reasoning.

--- a/docs/adr/0046-e2e-suite-reuses-existing-servers.md
+++ b/docs/adr/0046-e2e-suite-reuses-existing-servers.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# The E2E suite reuses an already-running target instead of owning its own server lifecycle
+
+`e2e/web`'s `e2e`/`e2e-ci` tasks both use Playwright's `webServer` option with `reuseExistingServer: true`: if something is already answering at the target URL, Playwright runs against it as-is; otherwise it starts one itself via `web:start` (`ng serve`) and tears it down after. The same config branch serves both the interactive watch-mode task (`e2e`) and the one-shot CI task (`e2e-ci`) — there's no separate "CI mode" server-lifecycle path, only a `baseURL`/`webServer` branch on `process.env.CI`.
+
+**Local runs** target `web:start`'s dev server directly (`https://localhost.www.craftsmans-ledger.dev:8080`, per [ADR-0029](./0029-local-dev-hostname-convention.md)/[ADR-0030](./0030-web-dev-server-https-only.md)) — there is no Compose/Caddy environment locally, and none is planned as part of this: [ADR-0039](./0039-web-e2e-environment-ci-only-compose-caddy.md)'s "CI-only for now" stays exactly as decided, with local reproducibility still deferred rather than picked up by this suite landing.
+
+**CI runs** target the Compose+Caddy E2E environment (`https://localhost:8443`) and carry no `webServer.command` fallback at all. Readiness is instead guaranteed upstream: `compose.yaml` now declares `healthcheck`s on both `web` (`wget --spider` against `http://127.0.0.1:8080/` — `localhost` doesn't work here, since nginx's bare `listen 8080` only binds the IPv4 wildcard and `localhost` inside the container can resolve to the IPv6 loopback first, verified by reproducing the connection-refused failure directly) and `caddy` (`wget --spider --no-check-certificate` against its self-signed `tls internal` cert), with `caddy`'s `depends_on` upgraded to `condition: service_healthy`. The CI job's `docker compose up -d` gained `--wait`, which blocks and fails that step itself if either service doesn't turn healthy — before `e2e-ci` ever runs. Omitting the fallback in CI is deliberate: a `webServer.command` that could silently start `web:start` there would mean a broken container environment degrades to testing the plain dev server instead of the promoted image, defeating the reason the environment exists. This also replaces the previous ad-hoc `curl --retry-all-errors` smoke-test step, which existed only as a stand-in readiness proof before a real suite existed.
+
+## Consequences
+
+- A future local Compose/Caddy setup (if ADR-0039's deferred local reproducibility is ever picked up) would need `playwright.config.ts`'s local branch revisited — it currently assumes `web:start` unconditionally.
+- The CI `web` healthcheck's `127.0.0.1`-over-`localhost` fix is specific to this nginx image's `listen 8080` (no explicit bind address); a different runtime image's health check can't assume the same fix applies without checking its own bind behavior.
+- If `docker compose up --wait` times out or a health check never turns healthy, the CI job fails at the "Start E2E environment" step with a compose-level error, not a Playwright error — that's the intended diagnostic split (environment failure vs. suite failure), matching the existing `docker-web`/`e2e-web` job-separation rationale in ADR-0039.

--- a/e2e/web/README.md
+++ b/e2e/web/README.md
@@ -1,0 +1,18 @@
+# E2E Web
+
+![Playwright](https://img.shields.io/badge/playwright-1.61.1-2EAD33)
+
+Playwright E2E suite that exercises [`web`](../../apps/web) by driving a real browser against it — the *E2E suite*, distinct from the *E2E environment* (`apps/web/.docker/`). See [CONTEXT.md](../../CONTEXT.md) for the canonical terms.
+
+In CI, this runs against the Compose+Caddy E2E environment (`https://localhost:8443`), which must already be healthy before `e2e-ci` starts. Locally, there's no Compose environment — tests run against `web`'s own dev server (`https://localhost.www.craftsmans-ledger.dev:8080`), reusing an already-running instance if `web:start` is already serving.
+
+## Commands
+
+Run these via moon from the repo root, not `playwright` directly — moon owns task orchestration/caching for the whole workspace (see [ADR-0001](../../docs/adr/0001-moonrepo-mise-pnpm-for-monorepo-tooling.md)):
+
+```bash
+pnpm moon run e2e-web:e2e         # Playwright UI mode, against a local dev server
+pnpm moon run e2e-web:e2e-ci      # Playwright once, headless, HTML report on failure
+pnpm moon run e2e-web:lint-ts     # ESLint
+pnpm moon run e2e-web:typecheck   # tsc --noEmit
+```

--- a/e2e/web/eslint.config.mts
+++ b/e2e/web/eslint.config.mts
@@ -1,0 +1,14 @@
+import base from '@craftsmans-ledger/eslint-config/base';
+import { defineConfig } from 'eslint/config';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+export default defineConfig(base, {
+    files: ['**/*.ts'],
+    languageOptions: {
+        parserOptions: {
+            projectService: true,
+            tsconfigRootDir: dirname(fileURLToPath(import.meta.url)),
+        },
+    },
+});

--- a/e2e/web/moon.yml
+++ b/e2e/web/moon.yml
@@ -1,0 +1,45 @@
+$schema: '../../.moon/cache/schemas/project.json'
+id: 'e2e-web'
+layer: 'automation'
+stack: 'frontend'
+
+project:
+    title: 'E2E Web'
+    description: 'Playwright E2E suite that exercises `web` by driving a browser against it.'
+
+tasks:
+    e2e:
+        command: 'playwright test --ui'
+        toolchains: ['node']
+        deps: ['install-browsers']
+        options:
+            runInCI: false
+
+    e2e-ci:
+        command: 'playwright test'
+        toolchains: ['node']
+        deps: ['install-browsers']
+        inputs:
+            - 'playwright.config.ts'
+            - 'tests/**/*'
+            - 'tsconfig.json'
+        outputs:
+            - 'playwright-report'
+            - 'test-results'
+
+    lint-ts:
+        command: 'eslint .'
+        toolchains: ['node']
+        inputs:
+            - '*.ts'
+            - 'tests/**/*'
+            - 'eslint.config.mts'
+            - 'tsconfig.json'
+
+    typecheck:
+        command: 'tsc --noEmit -p tsconfig.json'
+        toolchains: ['node']
+        inputs:
+            - '*.ts'
+            - 'tests/**/*'
+            - 'tsconfig.json'

--- a/e2e/web/package.json
+++ b/e2e/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "e2e-web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Playwright E2E suite for `web`.",
+  "author": "NoNamer777",
+  "license": "MIT",
+  "homepage": "https://github.com/nonamer777/craftsmans-ledger/tree/main/e2e/web#readme",
+  "bugs": {
+    "url": "https://github.com/nonamer777/craftsmans-ledger/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nonamer777/craftsmans-ledger.git",
+    "directory": "e2e/web"
+  },
+  "devDependencies": {
+    "@craftsmans-ledger/eslint-config": "workspace:*",
+    "@craftsmans-ledger/tsconfig": "workspace:*",
+    "@playwright/test": "~1.61.1",
+    "@types/node": "catalog:tooling",
+    "eslint": "catalog:tooling",
+    "jiti": "catalog:tooling",
+    "typescript": "catalog:tooling"
+  }
+}

--- a/e2e/web/playwright.config.ts
+++ b/e2e/web/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// In CI, `web` is already up behind Caddy before this config is ever loaded —
+// `docker compose up --wait` (see apps/web/.docker/compose.yaml) blocks the CI job
+// itself until the environment reports healthy, so there's no `webServer` fallback
+// here: a broken environment should fail loudly rather than silently falling back to
+// `web:start`, which would mean testing the dev server instead of the built image.
+// Locally, there's no Compose/Caddy environment at all (CI-only, see ADR-0039) — tests
+// run against `web:start`'s dev server, reusing an already-running instance if there
+// is one.
+const isCI = !!process.env['CI'];
+
+export default defineConfig({
+    testDir: './tests',
+    fullyParallel: true,
+    forbidOnly: isCI,
+    retries: isCI ? 2 : 0,
+    reporter: isCI ? [['html', { open: 'never' }]] : 'list',
+    use: {
+        baseURL: isCI ? 'https://localhost:8443' : 'https://localhost.www.craftsmans-ledger.dev:8080',
+        ignoreHTTPSErrors: true,
+        trace: 'retain-on-failure',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+    ...(isCI
+        ? {}
+        : {
+              webServer: {
+                  command: 'pnpm moon run web:start',
+                  url: 'https://localhost.www.craftsmans-ledger.dev:8080',
+                  reuseExistingServer: true,
+                  ignoreHTTPSErrors: true,
+              },
+          }),
+});

--- a/e2e/web/tests/boot.spec.ts
+++ b/e2e/web/tests/boot.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test('loads the app shell', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).toHaveTitle('Web');
+    await expect(page.locator('h1')).toContainText('Hello, web');
+});

--- a/e2e/web/tsconfig.json
+++ b/e2e/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "@craftsmans-ledger/tsconfig/node.json",
+    "include": ["*.ts", "tests/**/*.ts"],
+    "compilerOptions": {
+        "types": ["node"]
+    }
+}

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -4,7 +4,7 @@ import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 export default defineConfig(
-    globalIgnores(['apps/**', 'libs/**', 'packages/**']),
+    globalIgnores(['apps/**', 'e2e/**', 'libs/**', 'packages/**']),
     {
         files: ['*.js', '*.mjs', '*.cjs', '*.ts', '*.mts'],
         extends: [base],

--- a/packages/eslint-config/base.mts
+++ b/packages/eslint-config/base.mts
@@ -4,7 +4,7 @@ import prettier from 'eslint-config-prettier';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-    globalIgnores(['dist/**', 'coverage/**', 'reports/**']),
+    globalIgnores(['dist/**', 'coverage/**', 'reports/**', 'playwright-report/**', 'test-results/**']),
     {
         files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
         extends: [js.configs.recommended, tseslint.configs.recommendedTypeChecked, tseslint.configs.stylisticTypeChecked, prettier],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,6 +439,30 @@ importers:
         specifier: ~4.1.9
         version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@28.1.0)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0))
 
+  e2e/web:
+    devDependencies:
+      '@craftsmans-ledger/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@craftsmans-ledger/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@playwright/test':
+        specifier: ~1.61.1
+        version: 1.61.1
+      '@types/node':
+        specifier: catalog:tooling
+        version: 24.13.2
+      eslint:
+        specifier: catalog:tooling
+        version: 10.6.0(jiti@2.7.0)
+      jiti:
+        specifier: catalog:tooling
+        version: 2.7.0
+      typescript:
+        specifier: catalog:tooling
+        version: 6.0.3
+
   packages/eslint-config:
     dependencies:
       '@eslint/js':
@@ -1962,6 +1986,11 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -6373,6 +6402,10 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 $schema: 'https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/pnpm-workspace.json'
 packages:
     - apps/*
+    - e2e/*
     - libs/*
     - packages/*
 


### PR DESCRIPTION
## What

Adds `e2e-web`, a Playwright E2E suite for `web`, living in a new top-level `e2e/` project category alongside `apps/`, `libs/`, and `packages/`. Wires it into the `e2e-web` CI job in place of the old `curl` smoke-test, gated by new Compose healthchecks (`docker compose up --wait`) instead of a retry loop.

## Why

ADR-0039 stood up the Compose+Caddy E2E environment but explicitly deferred the actual test suite and left open how it would reach that environment. This closes that gap: a real Playwright suite now exercises `web`, locally against its dev server and in CI against the built container image, reusing an already-running target instead of owning its own server lifecycle either way.

Closes #94

## How to Review

Start with [ADR-0045](docs/adr/0045-e2e-top-level-category-for-e2e-suites.md) and [ADR-0046](docs/adr/0046-e2e-suite-reuses-existing-servers.md) for the design rationale, then `e2e/web/playwright.config.ts` for how the CI/local split actually works. The `compose.yaml` healthcheck change is worth a close look — the `web` healthcheck uses `127.0.0.1` rather than `localhost` deliberately (nginx's `listen 8080` only binds the IPv4 wildcard, so `localhost` intermittently resolves to the IPv6 loopback and fails). The remaining commits (workspace glob, eslint-config fix, README updates) are small and safe to skim.

## Testing

- [x] `pnpm moon ci` passes locally
- [x] Manually verified: built the real `web` Docker image, brought up the Compose+Caddy environment with the new `--wait`/healthcheck gating, and ran `e2e-ci` against it in CI mode — passed. Also ran `e2e-ci` locally to confirm the `webServer` fallback correctly spawns `web:start` when nothing is already serving (confirmed via a pre-existing, unrelated local port-8080 conflict on this machine, not by this change).

## Deployment Notes

None.
