### PR TITLE
docs: Add per-package CHANGELOG.md convention

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,3 +20,12 @@ _Avoid_: E2E environment (that's the distinct, CI-only, ephemeral stack used per
 
 **Dev environment**:  
 A persistent Docker Compose stack tracking the `next` tag, redeployed via Watchtower only after the staging environment's E2E run succeeds. Also serves as a manual/human verification environment — not itself a target for automated E2E runs, so it isn't disturbed by test traffic while someone is checking it.
+
+### Changelogs
+
+**Changelog**:  
+A per-package `CHANGELOG.md` following Keep a Changelog, listing consumer-relevant changes to that package/app under a single, frozen `Unreleased` section — see [ADR 0048](docs/adr/0048-keep-a-changelog-per-package-unreleased-only.md). Only projects under `apps/`, `packages/`, and `libs/` have one; `e2e/` suites don't.  
+_Avoid_: Release notes
+
+**Consumer-relevant change**:  
+A change that affects what a consumer of a package or app — the end user for `web`, a dependent workspace package for the tooling configs — experiences or can do. The litmus test for whether something belongs in a `CHANGELOG.md`; internal refactors, tests, and tooling churn with no observable effect don't qualify, regardless of commit type.

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this app will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- Initial application shell, scaffolded and ready for the app's real features to land.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,6 +6,8 @@
 
 Main Angular web client for Craftsman's Ledger — track unlocked recipes, find vendors, compare recipe profitability, and browse the tech tree.
 
+See [CHANGELOG.md](./CHANGELOG.md) for a history of changes.
+
 ## Commands
 
 Run these via moon from the repo root, not `ng` directly — moon owns task orchestration/caching for the whole workspace (see [ADR-0001](../../docs/adr/0001-moonrepo-mise-pnpm-for-monorepo-tooling.md)):

--- a/docs/adr/0048-keep-a-changelog-per-package-unreleased-only.md
+++ b/docs/adr/0048-keep-a-changelog-per-package-unreleased-only.md
@@ -1,0 +1,12 @@
+---
+status: accepted
+---
+
+# Keep a Changelog per package, frozen at Unreleased
+
+Every real project under `apps/`, `packages/`, and `libs/` gets a `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) format; `e2e/` suites are skipped since they're test code with no consumer to inform. Every package here stays pinned at `0.0.0` and is never published or released via semver — deployment happens through PR-numbered Docker tags promoted to `next` — so there's no version to hang a `## [x.y.z] - date` heading on. Rather than invent a fake version scheme just to satisfy the format, every entry lives under one flat, undated `## [Unreleased]` section indefinitely. An entry only belongs in a package's changelog if it's consumer-relevant: would a consumer of this package/app (the end user for `web`, a dependent workspace package for the tooling configs) need to know about it to understand what changed? Internal refactors, tests, and tooling churn with no observable effect don't qualify, regardless of what commit type produced them. The convention is enforced by PR review, not CI or a git hook — an automated check can't reliably distinguish consumer-relevant changes from internal ones.
+
+## Consequences
+
+- Revisiting real semantic versioning for these packages is explicitly deferred, not rejected. If/when that happens, this convention will need to introduce actual `## [x.y.z]` sections and stop treating `Unreleased` as a catch-all.
+- Existing packages (`apps/web`, `packages/eslint-config`, `packages/stylelint-config`, `packages/tsconfig`) were backfilled from git history, collapsed to reflect their current standing behavior rather than a full replay of every change and reversal along the way.

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `base.mts`: framework-agnostic flat config covering `@eslint/js`'s recommended rules, `typescript-eslint`'s `recommendedTypeChecked` and `stylisticTypeChecked` tiers, and `eslint-config-prettier`. Ignores `dist/`, `coverage/`, and `reports/`; relaxes `no-explicit-any` and `no-non-null-assertion` for `**/*.spec.ts`; disables type-aware rules for plain `.js`/`.mjs`/`.cjs` files.
+- `angular.mts`: overlay layering `angular-eslint`'s recommended, template, and template-accessibility configs on top of `base.mts`, with inline-template processing and a `.angular/` ignore.
+
+### Fixed
+
+- `base.mts` no longer runs type-aware rules against a project's own `eslint.config.mts` or `vitest.config.mts`, which can't be type-checked without a self-referential project setup.
+- `base.mts` now ignores Playwright's `test-results/` and `playwright-report/` output directories, alongside `dist/`, `coverage/`, and `reports/`.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -5,6 +5,8 @@
 
 Shared ESLint flat configs for Craftsman's Ledger apps.
 
+See [CHANGELOG.md](./CHANGELOG.md) for a history of changes.
+
 ## Usage
 
 `base.mts` holds framework-agnostic rules: `@eslint/js`'s recommended set, `typescript-eslint`'s `recommendedTypeChecked` and `stylisticTypeChecked` tiers ([ADR-0017](../../docs/adr/0017-typescript-eslint-recommended-type-checked.md)), and `eslint-config-prettier`. It also holds conventions that apply regardless of framework: ignores for generated output (`dist/`, `coverage/`, `reports/`), a relaxed `**/*.spec.ts` override for test code, and `typescript-eslint`'s `disableTypeChecked` for plain `.js`/`.mjs`/`.cjs` files that aren't covered by a tsconfig.

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `base.js`: extends `stylelint-config-standard-scss` and `stylelint-config-clean-order` for property ordering.
+- `angular.js`: overlay merging `base.js`'s rules and allowlisting Tailwind v4's CSS-first at-rules (`@theme`, `@utility`, `@variant`, `@apply`, `@plugin`, `@source`) via `scss/at-rule-no-unknown`, since `stylelint-config-recommended-scss` disables the core `at-rule-no-unknown` check entirely rather than parse SCSS-specific at-rules.

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -4,6 +4,8 @@
 
 Shared Stylelint configs for Craftsman's Ledger apps.
 
+See [CHANGELOG.md](./CHANGELOG.md) for a history of changes.
+
 ## Usage
 
 `base.js` holds framework-agnostic rules: `stylelint-config-standard-scss` and `stylelint-config-clean-order` for property ordering ([ADR-0018](../../docs/adr/0018-stylelint-clean-order-over-recess-order.md)).

--- a/packages/tsconfig/CHANGELOG.md
+++ b/packages/tsconfig/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `base.json`: environment-agnostic compiler options — the `strict` family, unused-code checks, `esModuleInterop`, `noFallthroughCasesInSwitch`, `isolatedModules`, `importHelpers`, and more — deliberately omitting `target`/`module`/`moduleResolution`/`lib` so framework overlays can pin their own.
+- `angular.json`: overlay extending `base.json` with Angular's `target`/`module`/`moduleResolution`/`lib` values.
+- `node.json`: overlay extending `base.json` for plain Node ESM packages authoring their own TypeScript, using `nodenext` module resolution and explicit `.mts` import extensions.

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -4,6 +4,8 @@
 
 Shared, environment-agnostic TypeScript compiler options for Craftsman's Ledger apps.
 
+See [CHANGELOG.md](./CHANGELOG.md) for a history of changes.
+
 ## Usage
 
 `base.json` deliberately excludes `target`, `module`, `moduleResolution`, and `lib` — those are environment-specific and belong to a framework overlay. See [ADR-0011](../../docs/adr/0011-per-framework-typescript-catalogs.md) for the rationale.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## What

Adds a `CHANGELOG.md` to `apps/web`, `packages/eslint-config`, `packages/stylelint-config`, and `packages/tsconfig`, following the Keep a Changelog format. Each is backfilled from git history and collapsed to reflect current standing behavior, and each package's `README.md` now links to its `CHANGELOG.md`. Records the convention as [ADR-0048](docs/adr/0048-keep-a-changelog-per-package-unreleased-only.md) and adds "Changelog" and "Consumer-relevant change" glossary terms to `CONTEXT.md`.

## Why

Closes #96. Every package here is pinned at `0.0.0` with no real semver release process (deployment happens via PR-numbered Docker tags), so entries live under one flat, undated `## [Unreleased]` section instead of versioned headings — real versioning is deferred, not rejected. Only consumer-relevant changes qualify for an entry (would a consumer of the package/app need to know about this?), keeping the changelogs signal-dense rather than a mirror of git log. The convention is enforced through PR review, not tooling, since an automated check can't reliably tell a consumer-relevant change from an internal one.

## How to Review

Start with [ADR-0048](docs/adr/0048-keep-a-changelog-per-package-unreleased-only.md) for the full rationale. Then spot-check each package's `CHANGELOG.md` against its current source (`base.mts`/`angular.mts` for eslint-config, `base.js`/`angular.js` for stylelint-config, `base.json`/`angular.json`/`node.json` for tsconfig) to confirm the entries match current behavior. `apps/web/CHANGELOG.md` is intentionally sparse — the app is still the unmodified Angular CLI scaffold, so there's nothing end-user-facing to log yet.

## Testing

- [x] `pnpm moon ci` passes locally
- [x] Manually verified: docs-only change; `root:lint-md`, `root:format-check`, and `web:install-browsers` were the only affected tasks and all passed

## Deployment Notes

None.
